### PR TITLE
Fix error in documentation

### DIFF
--- a/libsecret/secret-value.c
+++ b/libsecret/secret-value.c
@@ -176,7 +176,7 @@ secret_value_get (SecretValue *value,
  *
  * The content type must be `text/plain`.
  *
- * Returns: (nullable): the content type
+ * Returns: (nullable): the value
  */
 const gchar *
 secret_value_get_text (SecretValue *value)


### PR DESCRIPTION
I'm implementing password API for a Flutter plugin and found while reading the source code this 3 years old documentation bug. Just small, but it confused me.